### PR TITLE
Fix 500 error for favicon

### DIFF
--- a/copart_clone/urls.py
+++ b/copart_clone/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from django.urls import path, include
-from django.views.generic import TemplateView
+from django.urls import path, include, re_path
+from django.views.generic import TemplateView, RedirectView
+from django.conf import settings
 
 # Importa o módulo de views completo para evitar problemas de
 # referência a funções individuais durante o carregamento.
@@ -8,6 +9,10 @@ from . import views
 
 urlpatterns = [
     # Página inicial
+    re_path(r'^favicon\.ico/?$', RedirectView.as_view(
+        url=settings.STATIC_URL + 'images/favicon/copart/favicon.ico',
+        permanent=True
+    )),
     path('', views.home, name='home'),
 
     # URLs do app mirror


### PR DESCRIPTION
## Summary
- add explicit route for `favicon.ico`
- serve favicon using `RedirectView`

## Testing
- `python -m py_compile manage.py copart_clone/*.py mirror/*.py scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_684234eedce0832a9c0bcab9b85a08a5