### PR TITLE
Fix scraper paths

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -13,8 +13,8 @@ START_PAGES = [
     "/",  # página inicial
 ]
 
-TEMPLATE_DIR = "templates/copart"
-STATIC_DIR = "static/copart"
+TEMPLATE_DIR = os.path.join("copart_clone", "templates", "copart")
+STATIC_DIR = os.path.join("copart_clone", "static", "copart")
 
 # Mapeia URL de origem para o nome do arquivo HTML local
 URL_TO_SLUG = {}
@@ -123,6 +123,7 @@ def processar_pagina(page, url_path):
     
 def salvar_site():
     os.makedirs(STATIC_DIR, exist_ok=True)
+    os.makedirs(TEMPLATE_DIR, exist_ok=True)
     fila = deque(normalizar_caminho(p) for p in START_PAGES)
     visitados = set()
 


### PR DESCRIPTION
## Summary
- update template and static dir paths for scraper
- ensure directories exist before writing files

## Testing
- `python -m py_compile scraper.py`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68424973d11c832aa212ec236306250a