### PR TITLE
Fix scraper link queue and serve template

### DIFF
--- a/mirror/views.py
+++ b/mirror/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render, redirect
 
 def home_redirect(request):
     """Redireciona para a página inicial do clone"""
-    return redirect('/static/index.html')  # ou outro HTML espelhado
+    return render(request, 'copart/index.html')
 
 def admin_redirect(request):
     """Redireciona tentativas de acessar /admin"""

--- a/scraper.py
+++ b/scraper.py
@@ -122,6 +122,8 @@ def processar_pagina(page, url_path):
         f.write(html_final)
     print(f"[✓] Página salva: {url_path} → {html_path}")
 
+    return links
+
     
 def salvar_site():
     os.makedirs(STATIC_DIR, exist_ok=True)


### PR DESCRIPTION
## Summary
- return discovered links in the scraper
- render the mirrored index template instead of redirecting to a static file

## Testing
- `python -m py_compile scraper.py mirror/views.py`

------
https://chatgpt.com/codex/tasks/task_e_6848e2d38b64832abe190b2f685871d8