### PR TITLE
Improve scraper asset handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,7 +8,7 @@ venv\Scripts\activate
 pip install -r requirements.txt
 playwright install
 
-3. Rode o scraper:
+3. Rode o scraper (execute novamente sempre que quiser atualizar as páginas espelhadas):
 python scraper.py
 
 4. Rode o Django:

--- a/mirror/middleware.py
+++ b/mirror/middleware.py
@@ -5,8 +5,8 @@ from django.utils.deprecation import MiddlewareMixin
 class ClonedSiteMiddleware(MiddlewareMixin):
     def process_request(self, request):
         # Verifica se o template solicitado existe
-        path = request.path.lstrip('/') or 'index.html'
-        template_path = os.path.join('copart_clone/static', path)
+        path = request.path.lstrip('/') or 'index'
+        template_path = os.path.join('copart_clone/templates/copart', f"{path}.html")
         
         if os.path.exists(template_path):
             with open(template_path, 'r', encoding='utf-8') as f:

--- a/mirror/views.py
+++ b/mirror/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render, redirect
 
 def home_redirect(request):
     """Redireciona para a página inicial do clone"""
-    return redirect('/static/index.html')  # ou outro HTML espelhado
+    return render(request, 'copart/index.html')
 
 def admin_redirect(request):
     """Redireciona tentativas de acessar /admin"""


### PR DESCRIPTION
## Summary
- update documentation to clarify rerunning scraper
- search CSS for url() references and fetch those resources
- adjust ClonedSiteMiddleware to serve mirrored templates

## Testing
- `python -m py_compile scraper.py mirror/middleware.py`


------
https://chatgpt.com/codex/tasks/task_e_6848e2d38b64832abe190b2f685871d8