### PR TITLE
Improve scraper asset handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,7 +8,7 @@ venv\Scripts\activate
 pip install -r requirements.txt
 playwright install
 
-3. Rode o scraper:
+3. Rode o scraper **antes de iniciar o Django** (execute novamente sempre que quiser atualizar as páginas espelhadas):
 python scraper.py
 
 4. Rode o Django:

--- a/copart_clone/views.py
+++ b/copart_clone/views.py
@@ -19,7 +19,7 @@ def _serve_static_html(filename: str):
 
 
 def home(request):
-    return _serve_static_html('index.html')
+    return render(request, 'copart/index.html')
 
 def page(request, name):
     return _serve_static_html(f'{name}.html')

--- a/mirror/middleware.py
+++ b/mirror/middleware.py
@@ -5,8 +5,10 @@ from django.utils.deprecation import MiddlewareMixin
 class ClonedSiteMiddleware(MiddlewareMixin):
     def process_request(self, request):
         # Verifica se o template solicitado existe
-        path = request.path.lstrip('/') or 'index.html'
-        template_path = os.path.join('copart_clone/static', path)
+        path = request.path.lstrip('/') or 'index'
+        if not path.endswith('.html'):
+            path += '.html'
+        template_path = os.path.join('copart_clone/templates/copart', path)
         
         if os.path.exists(template_path):
             with open(template_path, 'r', encoding='utf-8') as f:

--- a/mirror/views.py
+++ b/mirror/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render, redirect
 
 def home_redirect(request):
     """Redireciona para a página inicial do clone"""
-    return redirect('/static/index.html')  # ou outro HTML espelhado
+    return render(request, 'copart/index.html')
 
 def admin_redirect(request):
     """Redireciona tentativas de acessar /admin"""

--- a/scraper.py
+++ b/scraper.py
@@ -56,6 +56,30 @@ def baixar_arquivo(url: str, destino: str) -> None:
         print(f"[!] Erro ao baixar {url}: {e}")
 
 
+def baixar_recursos_css(css_path: str, origem_url: str) -> None:
+    """Baixa recursos referenciados dentro de um CSS."""
+    try:
+        with open(css_path, "r", encoding="utf-8") as f:
+            conteudo = f.read()
+    except Exception:
+        return
+
+    def substituir(match: re.Match) -> str:
+        recurso = match.group(1).strip(" '\"")
+        if recurso.startswith("data:") or recurso.startswith("http"):
+            return match.group(0)
+        full = urllib.parse.urljoin(origem_url, recurso)
+        sanitized = sanitize_filename(recurso)
+        local = os.path.join(STATIC_DIR, sanitized)
+        baixar_arquivo(full, local)
+        return f"url('/static/copart/{sanitized}')"
+
+    novo_conteudo = re.sub(r"url\(([^)]+)\)", substituir, conteudo)
+    if novo_conteudo != conteudo:
+        with open(css_path, "w", encoding="utf-8") as f:
+            f.write(novo_conteudo)
+
+
 def proteger_template(html):
     html = re.sub(r"{{(.*?)}}", r"{% raw %}{{\1}}{% endraw %}", html)
     return html
@@ -109,6 +133,8 @@ def processar_pagina(page, url_path):
         sanitized = sanitize_filename(url)
         local_path = os.path.join(STATIC_DIR, sanitized)
         baixar_arquivo(full_url, local_path)
+        if local_path.endswith('.css'):
+            baixar_recursos_css(local_path, full_url)
         tag[attr] = f"/static/copart/{sanitized}"
 
     links = coletar_links(soup)
@@ -121,6 +147,8 @@ def processar_pagina(page, url_path):
     with open(html_path, "w", encoding="utf-8") as f:
         f.write(html_final)
     print(f"[✓] Página salva: {url_path} → {html_path}")
+
+    return links
 
     
 def salvar_site():


### PR DESCRIPTION
## Summary
- update documentation to clarify rerunning scraper
- search CSS for url() references and fetch those resources
- adjust ClonedSiteMiddleware to serve mirrored templates
- fix home view to render mirrored index

## Testing
- `python -m py_compile scraper.py mirror/middleware.py mirror/views.py copart_clone/views.py`


------
https://chatgpt.com/codex/tasks/task_e_6848e2d38b64832abe190b2f685871d8