### PR TITLE
Fix path separator handling in sanitize_filename

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -39,12 +39,15 @@ def normalizar_caminho(url_path: str) -> str:
 def sanitize_filename(url_path: str) -> str:
     """Sanitiza caminhos de arquivo mantendo a estrutura de pastas."""
     path = url_path.split("?")[0].split("#")[0].lstrip("/")
+    # Normaliza separadores para evitar duplicação de prefixo em sistemas Windows
+    path = path.replace("\\", "/")
     while path.startswith("static/copart/"):
         path = path[len("static/copart/") :]
     parts = [re.sub(r'[<>:"/\\|?*]', '_', p) for p in path.split("/") if p]
     if not parts:
         return "index"
-    return os.path.join(*parts)
+    # Sempre usa '/' para os caminhos retornados independentemente do SO
+    return "/".join(parts)
 
 
 def ajustar_para_portugues(path: str) -> str:


### PR DESCRIPTION
## Summary
- ensure sanitize_filename uses forward slashes
- normalize backslashes before prefix stripping

## Testing
- `python scraper.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684cc7342c0c832aa99d5dadec0526cd