### PR TITLE
Run scraper during deploy

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,7 +20,9 @@ http://127.0.0.1:8000/
 
 6. Para hospedar de forma gratuita na Render:
    - Conecte este repositório em um novo Web Service.
-   - A plataforma irá executar o `render.yaml`, instalar dependências, rodar o scraper e iniciar o Django automaticamente.
+   - A cada **Deploy latest commit**, o Render executará `build.sh` (conforme `render.yaml`).
+     Esse script instala dependências, roda o scraper e coleta arquivos estáticos
+     antes de iniciar o Django automaticamente.
 
 7. **Resolvido conflitos de merge:**
    - Caso o GitHub indique conflitos ao criar o pull request, clique em "Resolve conflicts".

--- a/render.yaml
+++ b/render.yaml
@@ -3,13 +3,9 @@ services:
     name: copart-clone
     env: python
     buildCommand: |
-      pip install -r requirements.txt
-      playwright install
-      playwright install --with-deps
+      bash build.sh
     startCommand: |
-      python scraper.py &&
       python manage.py migrate &&
-      python manage.py collectstatic --noinput &&
       gunicorn copart_clone.wsgi:application
     envVars:
       - key: DJANGO_SETTINGS_MODULE

--- a/scraper.py
+++ b/scraper.py
@@ -16,10 +16,24 @@ HEADERS = {
 }
 START_PAGES = [
     "/",  # página inicial
-    "/how-it-works/",  # guia de funcionamento
-    "/sellForIndividuals/",  # venda de veículos
-    "/doRegistration",  # cadastro
+    "/doRegistration/",  # cadastro
     "/login/",  # página de login
+    "/how-it-works/",  # guia de funcionamento
+    "/vehicleFinder/",  # buscador de veículos
+    "/salesListResult/",
+    "/public/watchList/",
+    "/savedsearch/",
+    "/vehicleAlerts/",
+    "/todaysAuction/",
+    "/auctionCalendar/",
+    "/locations/",
+    "/overview/",
+    "/content/br/pt-br/support/faq-topics/index",
+    "/Content/br/pt-BR/videos/about-copart",
+    "/content/br/pt-br/contact-us",
+    "/sellForIndividuals/",  # venda de veículos
+    "/search/compre_agora/",
+    "/Content/br/pt-BR/buy-it-now",
 ]
 
 TEMPLATE_DIR = os.path.join("copart_clone", "templates", "copart")
@@ -64,13 +78,12 @@ def sanitize_filename(url_path: str) -> str:
 def ajustar_para_portugues(path: str) -> str:
     """Força URLs para a versão em português.
 
-    Substitui qualquer segmento ``/en/`` por ``/pt-br/``. Isso evita que links
-    em inglês sejam seguidos e garante que todo o conteúdo espelhado use a
-    localização brasileira.
+    Converte segmentos ``/en/`` para ``/pt-br/`` apenas quando não estão
+    precedidos por ``/br``. Alguns caminhos do Copart utilizam ``/br/en`` mesmo
+    para conteúdo em português, por isso esses não devem ser alterados.
     """
 
-    # converte '/br/en/' ou '/en/' e demais ocorrências isoladas de '/en/'
-    path = re.sub(r"(^|/)en(?=/)", r"\1pt-br", path)
+    path = re.sub(r"(?<!/br)/en(?=/)", "/pt-br", path)
     return path
 
 def baixar_arquivo(url: str, destino: str) -> None:


### PR DESCRIPTION
## Summary
- streamline Render deployment
- make build script run on each deploy

## Testing
- `python -m py_compile scraper.py`
- `python scraper.py` *(fails: No module named 'requests')*
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686ec2349634832aad6299ccfd30b909