### PR TITLE
Fix MirrorConfig syntax error

### DIFF
--- a/mirror/apps.py
+++ b/mirror/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 
+
 class MirrorConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'    name = 'mirror'  # Isso deve corresponder ao nome do pacote
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'mirror'  # Isso deve corresponder ao nome do pacote
 


### PR DESCRIPTION
## Summary
- correct syntax in `mirror/apps.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686ed25a0a78832a8c5fe8a88b37f8ae