### PR TITLE
Add placeholder vehicleAlerts routes

### DIFF
--- a/copart_clone/templates/copart/vehicleAlerts_driverseat_mylots.html
+++ b/copart_clone/templates/copart/vehicleAlerts_driverseat_mylots.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Driver Seat - My Lots</title>
+</head>
+<body>
+    <h1>Driver Seat - My Lots</h1>
+    <p>No lots available at this time.</p>
+</body>
+</html>

--- a/copart_clone/templates/copart/vehicleAlerts_overview.html
+++ b/copart_clone/templates/copart/vehicleAlerts_overview.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Vehicle Alerts Overview</title>
+</head>
+<body>
+    <h1>Vehicle Alerts Overview</h1>
+    <p>This is a placeholder page for the vehicle alerts overview.</p>
+</body>
+</html>

--- a/copart_clone/urls.py
+++ b/copart_clone/urls.py
@@ -28,5 +28,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('cadastro/', views.cadastro_view, name='cadastro'),
     path('admin/copart_clone/agendar/<int:pk>/', views.agendar_scraper_view, name='copart_clone_agendar_scraper'),
+    path('vehicleAlerts/overview', views.vehicle_alerts_overview, name='vehicle_alerts_overview'),
+    path('vehicleAlerts/driverseat/mylots', views.vehicle_alerts_mylots, name='vehicle_alerts_mylots'),
     path('<str:name>/', views.page, name='page'),
 ]

--- a/copart_clone/views.py
+++ b/copart_clone/views.py
@@ -50,3 +50,13 @@ def agendar_scraper_view(request, pk):
         messages.error(request, f"Erro ao agendar scraper: {str(e)}")
 
     return HttpResponseRedirect(request.META.get('HTTP_REFERER', '/admin/'))
+
+
+def vehicle_alerts_overview(request):
+    """Return placeholder page for /vehicleAlerts/overview."""
+    return _serve_static_html('vehicleAlerts_overview.html')
+
+
+def vehicle_alerts_mylots(request):
+    """Return placeholder page for /vehicleAlerts/driverseat/mylots."""
+    return _serve_static_html('vehicleAlerts_driverseat_mylots.html')


### PR DESCRIPTION
## Summary
- add routes for `/vehicleAlerts/overview` and `/vehicleAlerts/driverseat/mylots`
- serve simple placeholder pages for the new endpoints

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68a65a541338832a8bb3f78f78dbc0b5