### PR TITLE
Avoid running scraper during build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,12 +10,10 @@ pip install -r requirements.txt
 
 # Instala Playwright
 export PLAYWRIGHT_BROWSERS_PATH=$PROJECT_DIR/.playwright
-python -m playwright install
-python -m playwright install-deps
 playwright install --with-deps
 
-# Executa o scraper
-python scraper.py
+# O scraper consome muitos recursos e não deve rodar durante o build.
+# Execute-o separadamente quando necessário.
 
 # Coleta arquivos estáticos
 python manage.py collectstatic --noinput

--- a/setup_render.sh
+++ b/setup_render.sh
@@ -4,12 +4,10 @@
 pip install -r requirements.txt
 
 # Configura o Playwright
-playwright install
-playwright install-deps
+export PLAYWRIGHT_BROWSERS_PATH=.playwright
 playwright install --with-deps
 
-# Executa o scraper
-python scraper.py
+# O scraper demanda muita memória e deve ser executado apenas sob demanda.
 
 # Configuração do Django
 python manage.py migrate


### PR DESCRIPTION
## Summary
- Remove redundant Playwright setup steps to lower memory usage
- Keep scraper execution out of build scripts to prevent OOM

## Testing
- `bash -n build.sh`
- `bash -n setup_render.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a70a671738832a9635e6309370638d