### PR TITLE
Handle nested public and lot paths

### DIFF
--- a/copart_clone/urls.py
+++ b/copart_clone/urls.py
@@ -30,5 +30,5 @@ urlpatterns = [
     path('admin/copart_clone/agendar/<int:pk>/', views.agendar_scraper_view, name='copart_clone_agendar_scraper'),
     path('vehicleAlerts/overview', views.vehicle_alerts_overview, name='vehicle_alerts_overview'),
     path('vehicleAlerts/driverseat/mylots', views.vehicle_alerts_mylots, name='vehicle_alerts_mylots'),
-    path('<str:name>/', views.page, name='page'),
+    re_path(r'^(?P<name>.+)$', views.page, name='page'),
 ]

--- a/copart_clone/views.py
+++ b/copart_clone/views.py
@@ -41,6 +41,21 @@ def home(request):
     return _serve_static_html('index.html')
 
 def page(request, name):
+    # Corrige URLs duplicadas como /public/public/watchList
+    match_public = re.match(r'^public/public/(.*)$', name)
+    if match_public:
+        return redirect('/public/' + match_public.group(1))
+    if name == 'public/public':
+        return redirect('/public/')
+
+    # Mapeia URLs de lotes para arquivos estáticos
+    lot_match = re.match(r'^lotSearchResults/lot/(\d+)(/Photos)?$', name)
+    if lot_match:
+        lot_id = lot_match.group(1)
+        suffix = '_Photos' if lot_match.group(2) else ''
+        filename = f'lot_{lot_id}{suffix}.html'
+        return _serve_static_html(filename)
+
     return _serve_static_html(f'{name}.html')
 
 def cadastro_view(request):


### PR DESCRIPTION
## Summary
- broaden URL routing to capture nested paths
- map `lotSearchResults` URLs to static lot pages and redirect duplicate `/public/public` paths

## Testing
- `python -m py_compile copart_clone/urls.py copart_clone/views.py`
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a74c342904832abfac0d4f32e7dcde