### PR TITLE
Serve robots.txt and remove unused static asset

### DIFF
--- a/copart_clone/templates/robots.txt
+++ b/copart_clone/templates/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /admin/
+

--- a/copart_clone/urls.py
+++ b/copart_clone/urls.py
@@ -30,5 +30,6 @@ urlpatterns = [
     path('admin/copart_clone/agendar/<int:pk>/', views.agendar_scraper_view, name='copart_clone_agendar_scraper'),
     path('vehicleAlerts/overview', views.vehicle_alerts_overview, name='vehicle_alerts_overview'),
     path('vehicleAlerts/driverseat/mylots', views.vehicle_alerts_mylots, name='vehicle_alerts_mylots'),
+    path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain'), name='robots'),
     re_path(r'^(?P<name>.+)$', views.page, name='page'),
 ]


### PR DESCRIPTION
## Summary
- serve `robots.txt` via Django to stop 404 bot requests
- remove unused WhatsApp icon from static files

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a7899464f8832a805ae95866b20d40