### PR TITLE
Handle vehicleFinderSearch lot URLs

### DIFF
--- a/copart_clone/views.py
+++ b/copart_clone/views.py
@@ -48,8 +48,8 @@ def page(request, name):
     if name == 'public/public':
         return redirect('/public/')
 
-    # Mapeia URLs de lotes para arquivos estáticos
-    lot_match = re.match(r'^lotSearchResults/lot/(\d+)(/Photos)?$', name)
+    # Mapeia URLs de lotes para arquivos estáticos em diferentes prefixos
+    lot_match = re.match(r'^(?:lotSearchResults|vehicleFinderSearch)/lot/(\d+)(/Photos)?$', name)
     if lot_match:
         lot_id = lot_match.group(1)
         suffix = '_Photos' if lot_match.group(2) else ''


### PR DESCRIPTION
## Summary
- map `vehicleFinderSearch/lot` URLs to existing lot templates
- drop temporary `index.html` so only scraper-generated templates remain

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a78f5c7bec832aac7f040017419c7c