### PR TITLE
Restore home page content

### DIFF
--- a/copart_clone/templates/copart/index.html
+++ b/copart_clone/templates/copart/index.html
@@ -1,7 +1,39 @@
-<html>
+<!DOCTYPE html>
+<html lang="pt-BR">
 <head>
-<meta content="noindex,nofollow" name="robots"/>
-<script src="/static/copart/_Incapsula_Resource">
-</script>
+  <meta charset="utf-8" />
+  <meta name="robots" content="noindex,nofollow" />
+  <title>CopartBR - Leilão de Veículos</title>
+  <style>
+    .wa-button {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      z-index: 10000;
+      background: #25D366;
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+      transition: all 0.3s ease;
+      text-decoration: none;
+      color: white;
+      font-size: 30px;
+      font-weight: bold;
+    }
+    .wa-button:hover {
+      transform: scale(1.1);
+      box-shadow: 0 6px 20px rgba(0,0,0,0.4);
+      background: #128C7E;
+    }
+  </style>
+</head>
 <body>
-<a class="wa-link" href="https://wa.me/5511958462009" style="position:fixed;bottom:20px;right:20px;background:#25D366;color:white;padding:10px;border-radius:50px;text-decoration:none;z-index:1000;" target="_blank">💬 WhatsApp</a></body></head></html>
+  <h1>🚗 CopartBR</h1>
+  <p>Bem-vindo ao espelho estático do CopartBR.</p>
+  <a class="wa-button" href="https://wa.me/5511958462009" target="_blank" title="Fale conosco no WhatsApp">💬</a>
+</body>
+</html>

--- a/copart_clone/views.py
+++ b/copart_clone/views.py
@@ -23,6 +23,8 @@ WHATSAPP_SNIPPET = (
 
 
 def _inject_whatsapp(html: str) -> str:
+    if re.search(r'wa-(?:fab|button|link)', html):
+        return html
     return re.sub(r'</body\s*>', WHATSAPP_SNIPPET + '</body>', html, flags=re.IGNORECASE)
 
 def _serve_static_html(filename: str):

--- a/public/index.html
+++ b/public/index.html
@@ -1,28 +1,39 @@
-<html style="height:100%"><head><base href="./"/><meta charset="utf-8"/><meta content="NOINDEX, NOFOLLOW" name="ROBOTS"/><meta content="telephone=no" name="format-detection"/><meta content="initial-scale=1.0" name="viewport"/><meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible"/><title>CopartBR - Leilão de Veículos</title><style>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="robots" content="noindex,nofollow" />
+  <title>CopartBR - Leilão de Veículos</title>
+  <style>
     .wa-button {
-        position: fixed;
-        bottom: 20px;
-        right: 20px;
-        z-index: 10000;
-        background: #25D366;
-        width: 60px;
-        height: 60px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.3);
-        transition: all 0.3s ease;
-        text-decoration: none;
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      z-index: 10000;
+      background: #25D366;
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+      transition: all 0.3s ease;
+      text-decoration: none;
+      color: white;
+      font-size: 30px;
+      font-weight: bold;
     }
     .wa-button:hover {
-        transform: scale(1.1);
-        box-shadow: 0 6px 20px rgba(0,0,0,0.4);
-        background: #128C7E;
+      transform: scale(1.1);
+      box-shadow: 0 6px 20px rgba(0,0,0,0.4);
+      background: #128C7E;
     }
-    .wa-icon {
-        color: white;
-        font-size: 30px;
-        font-weight: bold;
-    }
-    </style></head><body style="margin:0px;height:100%"><a class="wa-button" href="https://wa.me/5511958462009" target="_blank" title="Fale conosco no WhatsApp"><span class="wa-icon">💬</span></a></body></html>
+  </style>
+</head>
+<body>
+  <h1>🚗 CopartBR</h1>
+  <p>Bem-vindo ao espelho estático do CopartBR.</p>
+  <a class="wa-button" href="https://wa.me/5511958462009" target="_blank" title="Fale conosco no WhatsApp">💬</a>
+</body>
+</html>

--- a/static/copart/index.html
+++ b/static/copart/index.html
@@ -1,28 +1,39 @@
-<html style="height:100%"><head><base href="./"/><meta charset="utf-8"/><meta content="NOINDEX, NOFOLLOW" name="ROBOTS"/><meta content="telephone=no" name="format-detection"/><meta content="initial-scale=1.0" name="viewport"/><meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible"/><title>CopartBR - Leilão de Veículos</title><style>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="robots" content="noindex,nofollow" />
+  <title>CopartBR - Leilão de Veículos</title>
+  <style>
     .wa-button {
-        position: fixed;
-        bottom: 20px;
-        right: 20px;
-        z-index: 10000;
-        background: #25D366;
-        width: 60px;
-        height: 60px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.3);
-        transition: all 0.3s ease;
-        text-decoration: none;
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      z-index: 10000;
+      background: #25D366;
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+      transition: all 0.3s ease;
+      text-decoration: none;
+      color: white;
+      font-size: 30px;
+      font-weight: bold;
     }
     .wa-button:hover {
-        transform: scale(1.1);
-        box-shadow: 0 6px 20px rgba(0,0,0,0.4);
-        background: #128C7E;
+      transform: scale(1.1);
+      box-shadow: 0 6px 20px rgba(0,0,0,0.4);
+      background: #128C7E;
     }
-    .wa-icon {
-        color: white;
-        font-size: 30px;
-        font-weight: bold;
-    }
-    </style></head><body style="margin:0px;height:100%"><a class="wa-button" href="https://wa.me/5511958462009" target="_blank" title="Fale conosco no WhatsApp"><span class="wa-icon">💬</span></a></body></html>
+  </style>
+</head>
+<body>
+  <h1>🚗 CopartBR</h1>
+  <p>Bem-vindo ao espelho estático do CopartBR.</p>
+  <a class="wa-button" href="https://wa.me/5511958462009" target="_blank" title="Fale conosco no WhatsApp">💬</a>
+</body>
+</html>

--- a/templates/copart/index.html
+++ b/templates/copart/index.html
@@ -1,28 +1,39 @@
-<html style="height:100%"><head><base href="./"/><meta charset="utf-8"/><meta content="NOINDEX, NOFOLLOW" name="ROBOTS"/><meta content="telephone=no" name="format-detection"/><meta content="initial-scale=1.0" name="viewport"/><meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible"/><title>CopartBR - Leilão de Veículos</title><style>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="robots" content="noindex,nofollow" />
+  <title>CopartBR - Leilão de Veículos</title>
+  <style>
     .wa-button {
-        position: fixed;
-        bottom: 20px;
-        right: 20px;
-        z-index: 10000;
-        background: #25D366;
-        width: 60px;
-        height: 60px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.3);
-        transition: all 0.3s ease;
-        text-decoration: none;
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      z-index: 10000;
+      background: #25D366;
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+      transition: all 0.3s ease;
+      text-decoration: none;
+      color: white;
+      font-size: 30px;
+      font-weight: bold;
     }
     .wa-button:hover {
-        transform: scale(1.1);
-        box-shadow: 0 6px 20px rgba(0,0,0,0.4);
-        background: #128C7E;
+      transform: scale(1.1);
+      box-shadow: 0 6px 20px rgba(0,0,0,0.4);
+      background: #128C7E;
     }
-    .wa-icon {
-        color: white;
-        font-size: 30px;
-        font-weight: bold;
-    }
-    </style></head><body style="margin:0px;height:100%"><a class="wa-button" href="https://wa.me/5511958462009" target="_blank" title="Fale conosco no WhatsApp"><span class="wa-icon">💬</span></a></body></html>
+  </style>
+</head>
+<body>
+  <h1>🚗 CopartBR</h1>
+  <p>Bem-vindo ao espelho estático do CopartBR.</p>
+  <a class="wa-button" href="https://wa.me/5511958462009" target="_blank" title="Fale conosco no WhatsApp">💬</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace WhatsApp-only placeholder with simple CopartBR landing page
- skip WhatsApp snippet injection when page already has a button

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ab67319d20832aa946c0a0c9e77da2